### PR TITLE
Use decodeURIComponent to decode the cookie string

### DIFF
--- a/src/cookies.js
+++ b/src/cookies.js
@@ -48,5 +48,5 @@ export function getCookie(name) {
         }
     }
     // because unescape has been deprecated, replaced with decodeURI
-    return decodeURI(dc.substring(begin + prefix.length, end));
+    return decodeURIComponent(dc.substring(begin + prefix.length, end));
 }


### PR DESCRIPTION
decodeURI expects a fully formed uri such as https://mozilla.org/?x=%D1%88%D0%B5%D0%BB%D0%BB%D1%8B

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURI
for more information about decodeURI.