### PR TITLE
use insertBefore instead of innerHTML = ...

### DIFF
--- a/src/banner.js
+++ b/src/banner.js
@@ -16,8 +16,10 @@ export function showCookieConfirmation() {
  */
 export function insertCookieBanner(onAccept) {
   // add a css block to the inserted html
-  const html = `${bannerHtml} <style>${bannerCss.toString()}</style>`;
-  document.getElementsByTagName('body')[0].innerHTML = html + document.getElementsByTagName('body')[0].innerHTML;
+  const div = document.createElement('div');
+  div.innerHTML = bannerHtml;
+  div.innerHTML += `<style>${bannerCss.toString()}</style>`;
+  document.body.insertBefore(div, document.body.firstChild);
 
   document.getElementById('nhsuk-cookie-banner__link_accept').addEventListener('click', (e) => {
     e.preventDefault();


### PR DESCRIPTION
Do not rewrite innerHTML of the body element!
document.body.innerHTML = ...; will recreate the entire html document,
meaning that any event listeners already added will be removed.

Use insertBefore() instead to insert a new html node