### PR TITLE
Support multiple cookie types in one script

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -1,6 +1,6 @@
 import { getCookie as getRawCookie, createCookie as createRawCookie, deleteCookies } from './cookies';
 import { insertCookieBanner } from './banner';
-import { enableScriptsByCategory, enableIframesByCategory } from './enable';
+import { enableScriptsByCategories, enableIframesByCategories } from './enable';
 
 /**
  * If cookie rules/regulations change and the cookie itself needs to change,
@@ -219,11 +219,10 @@ export function onload() {
     setConsent(defaultConsent, COOKIE_TYPE.SESSION);
   }
 
-  // For each type, check the consent setting and enable the appropriate scripts and iframes
-  ['statistics', 'preferences', 'marketing'].forEach((cookieCategory) => {
-    if (getConsentSetting(cookieCategory) === true) {
-      enableScriptsByCategory(cookieCategory);
-      enableIframesByCategory(cookieCategory);
-    }
-  });
+  const allCategories = ['preferences', 'statistics', 'marketing'];
+  // Filter out categories that do not have user consent
+  const allowedCategories = allCategories.filter(category => getConsentSetting(category) === true);
+
+  enableScriptsByCategories(allowedCategories);
+  enableIframesByCategories(allowedCategories);
 }

--- a/src/cookieconsent.test.js
+++ b/src/cookieconsent.test.js
@@ -311,20 +311,18 @@ describe('onload', () => {
 
   test('enables the appropriate scripts', () => {
     const spy = jest.fn();
-    cookieconsent.__Rewire__('enableScriptsByCategory', spy);
+    cookieconsent.__Rewire__('enableScriptsByCategories', spy);
     onload();
-    expect(spy).toHaveBeenCalledWith('preferences');
-    expect(spy).not.toHaveBeenCalledWith('marketing');
-    cookieconsent.__ResetDependency__('enableScriptsByCategory');
+    expect(spy).toHaveBeenCalledWith(['preferences', 'statistics']);
+    cookieconsent.__ResetDependency__('enableScriptsByCategories');
   });
 
   test('enables the appropriate iframes', () => {
     const spy = jest.fn();
-    cookieconsent.__Rewire__('enableIframesByCategory', spy);
+    cookieconsent.__Rewire__('enableIframesByCategories', spy);
     onload();
-    expect(spy).toHaveBeenCalledWith('preferences');
-    expect(spy).not.toHaveBeenCalledWith('marketing');
-    cookieconsent.__ResetDependency__('enableIframesByCategory');
+    expect(spy).toHaveBeenCalledWith(['preferences', 'statistics']);
+    cookieconsent.__ResetDependency__('enableIframesByCategories');
   });
 });
 

--- a/src/enable.js
+++ b/src/enable.js
@@ -23,23 +23,46 @@ function enableIframe(iframe) {
   iframe.setAttribute('src', src);
 }
 
+/*
+ * Should a script or iframe be enabled, given it has a cookieconsent attribute
+ * value `cookieConsentAttribute` and the allowed categories are `allowedCategories`
+ * Returns true or false
+ */
+function shouldEnable(allowedCategories, cookieConsentAttribute) {
+  const cookieConsentTypes = cookieConsentAttribute.split(',');
+  for (let i = 0; i < cookieConsentTypes.length; i++) {
+    if (allowedCategories.indexOf(cookieConsentTypes[i]) === -1) {
+      // If *any* of the cookieConsentTypes are not in the allowedCategories array, return false.
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Enable all scripts for a given data-cookieconsent category
  */
-export function enableScriptsByCategory(category) {
-  const scripts = document.querySelectorAll(`script[data-cookieconsent="${category}"]`);
+export function enableScriptsByCategories(categories) {
+  const scripts = document.querySelectorAll('script[data-cookieconsent]');
   // Do not use scripts.forEach due to poor browser support with NodeList.forEach
   for (let i = 0; i < scripts.length; i++) {
-    enableScript(scripts[i]);
+    const cookieconsent = scripts[i].getAttribute('data-cookieconsent');
+    if (shouldEnable(categories, cookieconsent)) {
+      enableScript(scripts[i]);
+    }
   }
 }
 
 /**
  * Enable all iframes for a given data-cookieconsent category
  */
-export function enableIframesByCategory(category) {
-  const iframes = document.querySelectorAll(`iframe[data-cookieconsent="${category}"]`);
+export function enableIframesByCategories(categories) {
+  const iframes = document.querySelectorAll('iframe[data-cookieconsent]');
+  // Do not use iframes.forEach due to poor browser support with NodeList.forEach
   for (let i = 0; i < iframes.length; i++) {
-    enableIframe(iframes[i]);
+    const cookieconsent = iframes[i].getAttribute('data-cookieconsent');
+    if (shouldEnable(categories, cookieconsent)) {
+      enableIframe(iframes[i]);
+    }
   }
 }

--- a/src/enable.test.js
+++ b/src/enable.test.js
@@ -1,18 +1,17 @@
-/* global expect */
+/* global expect, jest */
+/* eslint-disable no-underscore-dangle */
 
-import { enableScriptsByCategory, enableIframesByCategory } from './enable';
+import enable, { enableScriptsByCategories, enableIframesByCategories } from './enable';
 
-test('enableScriptsByCategory is a function', () => {
-  expect(enableScriptsByCategory).toBeInstanceOf(Function);
-});
-
-test('enableScriptsByCategory enables javascript snippets', () => {
+test('enableScript enables a javascript snippet', () => {
+  const enableScript = enable.__get__('enableScript');
   document.body.innerHTML = '<script src="./abc.js" data-cookieconsent="abc" type="text/plain"></script>';
-  enableScriptsByCategory('abc');
+  const element = document.querySelector('script');
+  enableScript(element);
+
   const script = document.querySelector('script');
   const type = script.getAttribute('type');
   const src = script.getAttribute('src');
-
   expect(type).toBe('text/javascript');
   expect(src).toBe('./abc.js');
 });
@@ -24,18 +23,131 @@ test('enableScriptsByCategory enables inline javascript snippets', () => {
       window.inlineJsEnabled = true;
     </script>
   `;
-  enableScriptsByCategory('abc');
+  enableScriptsByCategories('abc');
 
   expect(window.inlineJsEnabled).toBe(true);
 });
 
 test('enableIframesByCategory is a function', () => {
-  expect(enableScriptsByCategory).toBeInstanceOf(Function);
+  expect(enableScriptsByCategories).toBeInstanceOf(Function);
 });
 
-test('enableIframesByCategory enables iframes', () => {
+test('enableIframe enables an iframe', () => {
+  const enableIframe = enable.__get__('enableIframe');
   document.body.innerHTML = '<iframe data-src="abc.html" data-cookieconsent="abc"></iframe>';
-  enableIframesByCategory('abc');
+  const element = document.querySelector('iframe');
+  enableIframe(element);
+
   const src = document.querySelector('iframe').getAttribute('src');
   expect(src).toBe('abc.html');
+});
+
+test('enableScriptsByCategories is a function', () => {
+  expect(enableScriptsByCategories).toBeInstanceOf(Function);
+});
+
+describe('enableScriptsByCategories enables javascript snippets', () => {
+  let spy;
+
+  beforeEach(() => {
+    spy = jest.fn();
+    enable.__Rewire__('enableScript', spy);
+  });
+
+  afterEach(() => {
+    enable.__ResetDependency__('enableScript');
+  });
+
+  test('for one matching category', () => {
+    document.body.innerHTML = '<script src="./abc.js" data-cookieconsent="abc" type="text/plain"></script>';
+    enableScriptsByCategories(['abc']);
+    const element = document.querySelector('script');
+    expect(spy).toHaveBeenCalledWith(element);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('for one matching category and one mismatch', () => {
+    document.body.innerHTML = '<script src="./abc.js" data-cookieconsent="abc" type="text/plain"></script>';
+    const element = document.querySelector('script');
+    document.body.innerHTML += '<script src="./xyz.js" data-cookieconsent="xyz" type="text/plain"></script>';
+    enableScriptsByCategories(['abc']);
+    expect(spy).toHaveBeenCalledWith(element);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('for a matching category with two cookie types', () => {
+    document.body.innerHTML = '<script src="./abc.js" data-cookieconsent="abc,xyz" type="text/plain"></script>';
+    const element = document.querySelector('script');
+    enableScriptsByCategories(['abc', 'xyz']);
+    expect(spy).toHaveBeenCalledWith(element);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('for two matching categories with two cookie types', () => {
+    document.body.innerHTML = '<script src="./abc.js" data-cookieconsent="abc" type="text/plain"></script>';
+    document.body.innerHTML += '<script src="./xyz.js" data-cookieconsent="xyz" type="text/plain"></script>';
+    enableScriptsByCategories(['abc', 'xyz']);
+    expect(spy).toHaveBeenCalledWith(document.querySelectorAll('script')[0]);
+    expect(spy).toHaveBeenCalledWith(document.querySelectorAll('script')[1]);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  test('for no matches', () => {
+    document.body.innerHTML = '<script src="./no-match.js" data-cookieconsent="no-match" type="text/plain"></script>';
+    enableScriptsByCategories(['abc', 'xyz']);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('enableIframesByCategories enables iframes', () => {
+  let spy;
+
+  beforeEach(() => {
+    spy = jest.fn();
+    enable.__Rewire__('enableIframe', spy);
+  });
+
+  afterEach(() => {
+    enable.__ResetDependency__('enableIframe');
+  });
+
+  test('for one matching category', () => {
+    document.body.innerHTML = '<iframe data-src="./abc.js" data-cookieconsent="abc"></iframe>';
+    enableIframesByCategories(['abc']);
+    const element = document.querySelector('iframe');
+    expect(spy).toHaveBeenCalledWith(element);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('for one matching category and one mismatch', () => {
+    document.body.innerHTML = '<iframe data-src="./abc.js" data-cookieconsent="abc"></iframe>';
+    const element = document.querySelector('iframe');
+    document.body.innerHTML += '<iframe data-src="./xyz.js" data-cookieconsent="xyz"></iframe>';
+    enableIframesByCategories(['abc']);
+    expect(spy).toHaveBeenCalledWith(element);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('for a matching category with two cookie types', () => {
+    document.body.innerHTML = '<iframe data-src="./abc.js" data-cookieconsent="abc,xyz"></iframe>';
+    const element = document.querySelector('iframe');
+    enableIframesByCategories(['abc', 'xyz']);
+    expect(spy).toHaveBeenCalledWith(element);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test('for two matching categories with two cookie types', () => {
+    document.body.innerHTML = '<iframe data-src="./abc.js" data-cookieconsent="abc"></iframe>';
+    document.body.innerHTML += '<iframe data-src="./xyz.js" data-cookieconsent="xyz"></iframe>';
+    enableIframesByCategories(['abc', 'xyz']);
+    expect(spy).toHaveBeenCalledWith(document.querySelectorAll('iframe')[0]);
+    expect(spy).toHaveBeenCalledWith(document.querySelectorAll('iframe')[1]);
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  test('for no matches', () => {
+    document.body.innerHTML = '<iframe data-src="./no-match.js" data-cookieconsent="no-match"></iframe>';
+    enableIframesByCategories(['abc', 'xyz']);
+    expect(spy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
The major internal change here is going from enableScriptsByCategory to
enableScriptsByCategories, where an array of strings is passed as the first
argument rather than a string.