### PR TITLE
use NHS.UK frontend color variables

### DIFF
--- a/src/_cookie-banner.scss
+++ b/src/_cookie-banner.scss
@@ -1,7 +1,7 @@
 .nhsuk-cookie-banner {
   background: white;
   position: relative;
-  box-shadow: 0 0 4px 0 black;
+  box-shadow: 0 0 4px 0 $color_nhsuk-black;
   padding: 24px 0 24px 0;
   width: 100%;
   z-index: 1;

--- a/src/_success-banner.scss
+++ b/src/_success-banner.scss
@@ -1,6 +1,6 @@
 .nhsuk-success-banner {
   background-color: $color_nhsuk-green;
-  color: white;
+  color: $color_nhsuk-white;
   padding: 8px 0 8px 0;
   position: relative;
 
@@ -8,11 +8,13 @@
     margin: 0;
   }
 
-  a, a:visited {
-    color: white;
+  a, 
+  a:visited {
+    color: $color_nhsuk-green;
   }
   
-  a:hover, a:focus {
-    color: black;
+  a:hover, 
+  a:focus {
+    color: $color_nhsuk-black;
   }
 }


### PR DESCRIPTION
We should use the NHS.UK frontend color variables rather than hex codes. 