### PR TITLE
Remove aria and banner attributes and accessibility fix

### DIFF
--- a/src/banner.html
+++ b/src/banner.html
@@ -1,17 +1,17 @@
 <div id="nhsuk-cookie-banner">
-  <div class="nhsuk-cookie-banner" id="cookiebanner" aria-label="Cookie banner" role="banner">
+  <div class="nhsuk-cookie-banner" id="cookiebanner">
     <div class="nhsuk-width-container">
       <p>We've put small files called cookies on your device to make the website better.</p>
       <ul>
-        <li id="nhsuk-cookie-banner__link_accept"><a href="#" tabindex="1"><strong>I'm OK with cookies</strong></a></li>
-        <li id="nhsuk-cookie-banner__link"><a href="/our-policies/cookies-policy" tabindex="2">Turn cookies on or off</a></li>
+        <li id="nhsuk-cookie-banner__link_accept"><a href="#"><strong>I'm OK with cookies</strong></a></li>
+        <li id="nhsuk-cookie-banner__link"><a href="/our-policies/cookies-policy">Turn cookies on or off</a></li>
       </ul>
     </div>
   </div>
 
-  <div class="nhsuk-success-banner" id="nhsuk-cookie-confirmation-banner" style="display:none;" role="banner">
+  <div class="nhsuk-success-banner" id="nhsuk-cookie-confirmation-banner" style="display:none;">
     <div class="nhsuk-width-container">
-      <p>Your cookie settings have been saved. <a href="/our-policies/cookies-policy/">Turn cookies on or off</a></p>
+      <p><span id="nhsuk-success-banner__message">Your cookie settings have been saved.</span> <a href="/our-policies/cookies-policy/">Turn cookies on or off</a></p>
     </div>
   </div>
 </div>

--- a/src/banner.js
+++ b/src/banner.js
@@ -9,6 +9,19 @@ export function showCookieConfirmation() {
   document.getElementById('nhsuk-cookie-confirmation-banner').style.display = 'block';
 }
 
+export function addFocusCookieConfirmation() {
+  const cookieConfirmationMessage = document.getElementById('nhsuk-success-banner__message');
+  cookieConfirmationMessage.setAttribute('tabIndex', '-1');
+  cookieConfirmationMessage.focus();
+}
+
+export function removeFocusCookieConfirmation() {
+  const cookieConfirmationMessage = document.getElementById('nhsuk-success-banner__message');
+  cookieConfirmationMessage.addEventListener('blur', (e) => {
+    cookieConfirmationMessage.removeAttribute('tabIndex');
+  });
+}
+
 /**
  * Insert the cookie banner at the top of a page.
  * args:
@@ -26,6 +39,8 @@ export function insertCookieBanner(onAccept) {
     onAccept();
     hideCookieBanner();
     showCookieConfirmation();
+    addFocusCookieConfirmation();
+    removeFocusCookieConfirmation();
   });
   document.getElementById('nhsuk-cookie-banner__link').addEventListener('click', () => {
     onAccept();


### PR DESCRIPTION
Removed the aria label and banner role of the cookie banner div.
Shouldn't really have more than one banner as the header element already has
the banner role. The aria label is therefore not needed.
Accessibility fix - When clicking on the "I'm OK with cookies" link,
made sure focus next goes on to the banner saved message so screen
readers are given immediate feedback.