### PR TITLE
updated package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-consent",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-consent",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "In-house solution for managing cookies on nhs.uk",
   "main": "src/cookieconsent.js",
   "directories": {


### PR DESCRIPTION
Release notes: 

- Can now configure the policy page link in the banner at build or run time.
- Consent is now no longer accepted when going to the policy page, but is when the save button is clicked
- Confirmation banner changes. When the back button is pressed after saving changes, it goes back to main site
- Visual policy page fixes
- Accessibility fixes for confirmation banner