### PR TITLE
Allow title and body to be customised

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,22 @@ The cookie banner will not show on the policy page, even if you have embedded th
 This is because the user does not need to be presented with a cookie banner if they are on the page
 which can manage cookies.
 
+### `data-banner-title`
+
+By default the banner title reads "Cookies on the NHS website". If you want this to be different (for example, this is being deployed to a subsite), you can set this variable.
+
+```html
+<script src="./cookie-consent.js" data-banner-title="Cookies on the NHSX Website" type="text/javascript"></script>
+```
+
+### `data-services-used`
+
+By default, the banner tells users the site collects cookies for "services called Adobe Analytics, Hotjar and Google Analytics". If this differs for your site, you can set this variable:
+
+```html
+<script src="./cookie-consent.js" data-services-used="Google Analytics" type="text/javascript"></script>
+```
+
 ## Javascript API
 
 The javascript API is exposed on a NHSCookieConsent global variable.
@@ -67,9 +83,9 @@ console.log(NHSCookieConsent.VERSION)
 
 - `getPreferences()`
 - `getStatistics()`
-- `getMarketing()` 
+- `getMarketing()`
 
-These methods get the status of the cookie consent for that type of cookie.  
+These methods get the status of the cookie consent for that type of cookie.
 Returns a boolean.
 
 - `getConsented()`
@@ -81,8 +97,8 @@ It is primarily used to hide the banner once consent has been given.
 - `setStatistics(value)`
 - `setMarketing(value)`
 
-These methods set the status of the cookie consent for that type of cookie.  
-set methods should only be used in response to a user interaction accepting that type of cookie.  
+These methods set the status of the cookie consent for that type of cookie.
+set methods should only be used in response to a user interaction accepting that type of cookie.
 Expects a boolean `value` argument.
 
 - `setConsented(value)`
@@ -139,6 +155,22 @@ POLICY_URL=/custom/policy/url/ npm run build:production
 Set to `true` a logging URL will be hit when the banner shown, analytics are accepted or analytics are not accepted.
 ```sh
 LOG_TO_SPLUNK=true npm run build:production
+```
+
+#### `BANNER_TITLE`
+
+By default the banner title reads "Cookies on the NHS website". If you want this to be different (for example, this is being deployed to a subsite), you can set this variable.
+
+```sh
+BANNER_TITLE="Cookies on the NHSX website" npm build:production
+```
+
+#### `SERVICES_USED`
+
+By default, the banner tells users the site collects cookies for "services called Adobe Analytics, Hotjar and Google Analytics". If this differs for your site, you can set this variable:
+
+```sh
+SERVICES_USED="Google Analytics" npm build:production
 ```
 
 ## Tests

--- a/src/banner.html
+++ b/src/banner.html
@@ -1,11 +1,11 @@
 <div id="nhsuk-cookie-banner">
   <div class="nhsuk-cookie-banner" id="cookiebanner">
-    <div class="nhsuk-width-container"> 
-        <h2>Cookies on the NHS website</h2> 
+    <div class="nhsuk-width-container">
+        <h2>${require('./settings.js').getBannerTitle()}</h2>
         <p>We've put some small files called cookies on your device to make our site work.</p>
         <p>We'd also like to use analytics cookies. These send information about how our site is used to services called Adobe Analytics, Hotjar and Google Analytics. We use this information to improve our site.</p>
         <p>Let us know if this is OK. We'll use a cookie to save your choice. You can <a id="nhsuk-cookie-banner__link" href="${require('./settings.js').getPolicyUrl()}" tabindex="1">read more about our cookies</a> before you choose.</p>
-        <ul> 
+        <ul>
             <li><button class='nhsuk-button' id="nhsuk-cookie-banner__link_accept_analytics" href="#" tabindex="2">I'm OK with analytics cookies</button></li>
             <li><button class='nhsuk-button' id="nhsuk-cookie-banner__link_accept" href="#" tabindex="3">Do not use analytics cookies</button></li>
         </ul>

--- a/src/banner.html
+++ b/src/banner.html
@@ -3,7 +3,7 @@
     <div class="nhsuk-width-container">
         <h2>${require('./settings.js').getBannerTitle()}</h2>
         <p>We've put some small files called cookies on your device to make our site work.</p>
-        <p>We'd also like to use analytics cookies. These send information about how our site is used to services called Adobe Analytics, Hotjar and Google Analytics. We use this information to improve our site.</p>
+        <p>We'd also like to use analytics cookies. These send information about how our site is used to ${require('./settings.js').getServicesUsed()}. We use this information to improve our site.</p>
         <p>Let us know if this is OK. We'll use a cookie to save your choice. You can <a id="nhsuk-cookie-banner__link" href="${require('./settings.js').getPolicyUrl()}" tabindex="1">read more about our cookies</a> before you choose.</p>
         <ul>
             <li><button class='nhsuk-button' id="nhsuk-cookie-banner__link_accept_analytics" href="#" tabindex="2">I'm OK with analytics cookies</button></li>

--- a/src/settings.js
+++ b/src/settings.js
@@ -47,3 +47,19 @@ export function getNoBanner() {
 
   return defaults;
 }
+
+// get properties from the scriptTag for the bannner title
+export function getBannerTitle() {
+  let dataBannnerTitle = 'Cookies on the NHS Website';
+
+  if (process.env.BANNER_TITLE) {
+    dataBannnerTitle = process.env.BANNER_TITLE;
+  }
+
+  if (scriptTag.getAttribute('data-banner-title')) {
+    dataBannnerTitle = scriptTag.getAttribute('data-banner-title');
+  }
+
+  return dataBannnerTitle;
+}
+

--- a/src/settings.js
+++ b/src/settings.js
@@ -63,3 +63,18 @@ export function getBannerTitle() {
   return dataBannnerTitle;
 }
 
+// get properties from the scriptTag for the services used
+export function getServicesUsed() {
+  let dataServicesUsed = 'services called Adobe Analytics, Hotjar and Google Analytics';
+
+  if (process.env.SERVICES_USED) {
+    dataServicesUsed = process.env.SERVICES_USED;
+  }
+
+  if (scriptTag.getAttribute('data-services-used')) {
+    dataServicesUsed = scriptTag.getAttribute('data-services-used');
+  }
+
+  return dataServicesUsed;
+}
+

--- a/src/settings.test.js
+++ b/src/settings.test.js
@@ -1,7 +1,9 @@
 /* global expect, jest, afterEach */
 /* eslint-disable no-underscore-dangle */
 
-import settings, { getNoBanner, getPolicyUrl, makeUrlAbsolute } from './settings';
+import settings, {
+  getNoBanner, getPolicyUrl, makeUrlAbsolute, getBannerTitle,
+} from './settings';
 
 describe('get script settings for no banner', () => {
   afterEach(() => {
@@ -104,6 +106,53 @@ describe('get an absolute URL', () => {
   test('when the URL has a hash fragment', () => {
     const url = '/path/to/page.html#section-2';
     expect(makeUrlAbsolute(url)).toBe('http://localhost/path/to/page.html#section-2');
+  });
+});
+
+describe('testing getBannerTitle with environment variables and custom tags', () => {
+  // need to set up a temporary environment variable
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    settings.__ResetDependency__('scriptTag');
+  });
+
+  test('getBannerTitle returns environment variable when one is set', () => {
+    // Resets the module registry - the cache of all required modules.
+    // This is useful to isolate modules where local state might conflict between tests.
+    const scriptTag = document.createElement('script');
+    settings.__Rewire__('scriptTag', scriptTag);
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.BANNER_TITLE = 'Cookies on the example.com site';
+    expect(getBannerTitle()).toEqual('Cookies on the example.com site');
+    process.env = OLD_ENV;
+  });
+
+  test('getBannerTitle returns custom tag when one is set', () => {
+    const scriptTag = document.createElement('script');
+    settings.__Rewire__('scriptTag', scriptTag);
+    scriptTag.setAttribute('data-banner-title', 'Cookies on the example.com site');
+    expect(getBannerTitle()).toEqual('Cookies on the example.com site');
+  });
+
+  test('getBannerTitle returns default value when no env var or custom tag', () => {
+    const scriptTag = document.createElement('script');
+    settings.__Rewire__('scriptTag', scriptTag);
+    expect(getBannerTitle()).toEqual('Cookies on the NHS Website');
+    settings.__ResetDependency__('dataPolicyScript');
+  });
+
+  test('getBannerTitle returns custom tag when both tag and env var are set', () => {
+    const scriptTag = document.createElement('script');
+    settings.__Rewire__('scriptTag', scriptTag);
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.BANNER_TITLE = 'Cookies on the example.com site';
+    scriptTag.setAttribute('data-banner-title', 'data-test');
+    settings.__Rewire__('scriptTag', scriptTag);
+    expect(getBannerTitle()).toEqual('data-test');
+    process.env = OLD_ENV;
   });
 });
 

--- a/src/settings.test.js
+++ b/src/settings.test.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-underscore-dangle */
 
 import settings, {
-  getNoBanner, getPolicyUrl, makeUrlAbsolute, getBannerTitle,
+  getNoBanner, getPolicyUrl, makeUrlAbsolute, getBannerTitle, getServicesUsed,
 } from './settings';
 
 describe('get script settings for no banner', () => {
@@ -156,3 +156,49 @@ describe('testing getBannerTitle with environment variables and custom tags', ()
   });
 });
 
+describe('testing getServicesUsed with environment variables and custom tags', () => {
+  // need to set up a temporary environment variable
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    settings.__ResetDependency__('scriptTag');
+  });
+
+  test('getServicesUsed returns environment variable when one is set', () => {
+    // Resets the module registry - the cache of all required modules.
+    // This is useful to isolate modules where local state might conflict between tests.
+    const scriptTag = document.createElement('script');
+    settings.__Rewire__('scriptTag', scriptTag);
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.SERVICES_USED = 'Google Analytics';
+    expect(getServicesUsed()).toEqual('Google Analytics');
+    process.env = OLD_ENV;
+  });
+
+  test('getServicesUsed returns custom tag when one is set', () => {
+    const scriptTag = document.createElement('script');
+    settings.__Rewire__('scriptTag', scriptTag);
+    scriptTag.setAttribute('data-services-used', 'Google Analytics');
+    expect(getServicesUsed()).toEqual('Google Analytics');
+  });
+
+  test('getServicesUsed returns default value when no env var or custom tag', () => {
+    const scriptTag = document.createElement('script');
+    settings.__Rewire__('scriptTag', scriptTag);
+    expect(getServicesUsed()).toEqual('services called Adobe Analytics, Hotjar and Google Analytics');
+    settings.__ResetDependency__('dataPolicyScript');
+  });
+
+  test('getServicesUsed returns custom tag when both tag and env var are set', () => {
+    const scriptTag = document.createElement('script');
+    settings.__Rewire__('scriptTag', scriptTag);
+    jest.resetModules();
+    process.env = { ...OLD_ENV };
+    process.env.SERVICES_USED = 'Google Analytics';
+    scriptTag.setAttribute('data-services-used', 'data-test');
+    settings.__Rewire__('scriptTag', scriptTag);
+    expect(getServicesUsed()).toEqual('data-test');
+    process.env = OLD_ENV;
+  });
+});

--- a/tests/example/custom-services.html
+++ b/tests/example/custom-services.html
@@ -1,0 +1,38 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
+
+    <link rel="shortcut icon" href="">
+
+    <title>Cookie Consent test page</title>
+
+    <link rel="stylesheet" href="./css/style.css">
+
+    <!-- Necessary cookies should always be set regardless of user preferences  -->
+    <script src="./js/necessary.js"></script>
+
+    <!-- Statistics cookies have to be accepted before they are set -->
+    <script src="./js/statistics.js" data-cookieconsent="statistics" type="text/plain"></script>
+
+    <!-- Cookie Consent plugin -->
+    <script src="../../dist/main.js" data-services-used="some custom service" type="text/javascript"></script>
+
+    <script type="text/plain" data-cookieconsent="statistics">
+      document.cookie = 'inline-js=this cookie is from inline javascript';
+    </script>
+  </head>
+  <body>
+    <main class="main">
+      <h1>Cookies:</h1>
+      <button id="cookie-list-refresh">Refresh</button>
+      <div id="cookie-list"></div>
+
+      <iframe data-src="https://example.com" data-cookieconsent="statistics"></iframe>
+
+      <script src="./js/show-cookie-data.js"></script>
+    </main>
+  </body>
+</html>

--- a/tests/example/custom-title.html
+++ b/tests/example/custom-title.html
@@ -1,0 +1,38 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
+
+    <link rel="shortcut icon" href="">
+
+    <title>Cookie Consent test page</title>
+
+    <link rel="stylesheet" href="./css/style.css">
+
+    <!-- Necessary cookies should always be set regardless of user preferences  -->
+    <script src="./js/necessary.js"></script>
+
+    <!-- Statistics cookies have to be accepted before they are set -->
+    <script src="./js/statistics.js" data-cookieconsent="statistics" type="text/plain"></script>
+
+    <!-- Cookie Consent plugin -->
+    <script src="../../dist/main.js" data-banner-title="Cookies on the example.com site" type="text/javascript"></script>
+
+    <script type="text/plain" data-cookieconsent="statistics">
+      document.cookie = 'inline-js=this cookie is from inline javascript';
+    </script>
+  </head>
+  <body>
+    <main class="main">
+      <h1>Cookies:</h1>
+      <button id="cookie-list-refresh">Refresh</button>
+      <div id="cookie-list"></div>
+
+      <iframe data-src="https://example.com" data-cookieconsent="statistics"></iframe>
+
+      <script src="./js/show-cookie-data.js"></script>
+    </main>
+  </body>
+</html>

--- a/tests/integration-tests/banner.test.js
+++ b/tests/integration-tests/banner.test.js
@@ -137,3 +137,12 @@ describe('custom banner title', () => {
   });
 });
 
+describe('custom services used', () => {
+  it('shows custom title', async () => {
+    await clearAllCookies();
+    await page.goto('http://localhost:8080/tests/example/custom-services.html');
+    await waitForVisibleBanner();
+    await expect(page).toMatch('some custom service');
+  });
+});
+

--- a/tests/integration-tests/banner.test.js
+++ b/tests/integration-tests/banner.test.js
@@ -126,3 +126,14 @@ describe('custom banner url link', () => {
     expect(banner).not.toBe(null);
   });
 });
+
+describe('custom banner title', () => {
+  it('shows custom title', async () => {
+    await clearAllCookies();
+    await page.goto('http://localhost:8080/tests/example/custom-title.html');
+    await waitForVisibleBanner();
+    const title = await page.evaluate(async () => document.querySelector('.nhsuk-cookie-banner h2').innerHTML);
+    expect(title).toEqual('Cookies on the example.com site');
+  });
+});
+


### PR DESCRIPTION
We've used this script on the NHSX website, which required a bit of tweaking in order for us to use it. Rather than having to edit the generated source JS (which we've done in the meantime), I thought it might be more future-proof (and useful for others), if we could set some customisation variables to set the title of the banner, and the list of services that are used.

Thoughts welcome!