### PR TITLE
Change event listener type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-consent",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-consent",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "In-house solution for managing cookies on nhs.uk",
   "main": "src/cookieconsent.js",
   "directories": {

--- a/src/main.js
+++ b/src/main.js
@@ -58,4 +58,4 @@ window.NHSCookieConsent = {
 };
 /* eslint-enable sort-keys */
 
-window.addEventListener('load', onload);
+window.addEventListener('DOMContentLoaded', onload);


### PR DESCRIPTION
Changes made for issue #108 

- Updated event listener type from `load` to `DOMContentLoaded`
- Updated package versions