### PR TITLE
Remove build action from test script and document

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ expiry date of the cookie.
 
 - `VERSION` the current version as defined in package.json
 
+<a name="compiling"></a>
 ## Compiling
 
 This project uses [Webpack](https://webpack.js.org/) and [Babel](https://babeljs.io/)
@@ -142,6 +143,8 @@ LOG_TO_SPLUNK=true npm run build:production
 ```
 
 ## Tests
+
+The tests require the javascript to be compiled. See the [Compiling](#compiling) section above.
 
 To run the [Jest](https://jestjs.io/en/) tests
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:production": "webpack --mode=production",
     "lint": "eslint .",
     "start": "npm run watch & npm run testserver",
-    "test": "npm run build && start-server-and-test testserver http://localhost:8080 test-all",
+    "test": "start-server-and-test testserver http://localhost:8080 test-all",
     "test-all": "npm-run-all --continue-on-error test:*",
     "test:unit": "jest --runInBand --coverage=true",
     "test:integration": "jest -c tests/integration-tests/jest.config.js --coverage=true",


### PR DESCRIPTION
JavaScript was built in production mode and then over-written by the build for the test script which is built in development mode.
The build action has been removed from the test script so that whatever has been built will be tested.
Azure pipeline now copies the correct js file format as a build archive.
Documentation updated.