### PR TITLE
Add dependency check results as an exclusion for sonarqube

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ steps:
     cliProjectKey: 'cookie-consent'
     extraProperties: |
         sonar.javascript.lcov.reportPaths=coverage/lcov.info
-        sonar.coverage.exclusions=**/*.config.js,**/coverage/**,**/integration-tests/**,**/tests/example/**,**/*.test.*,__mocks__/**,*test-environment.*,**/dependency-scan-results/**/*
+        sonar.coverage.exclusions=**/*.config.js,**/coverage/**,**/integration-tests/**,**/tests/example/**,**/*.test.*,__mocks__/**,*test-environment.*,**/dependency-scan-results/**/*,**/node_modules/**
 
 - script: npm run build:production
   displayName: 'build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ steps:
     cliProjectKey: 'cookie-consent'
     extraProperties: |
         sonar.javascript.lcov.reportPaths=coverage/lcov.info
-        sonar.coverage.exclusions=**/*.config.js,**/coverage/**,**/integration-tests/**,**/tests/example/**,**/*.test.*,__mocks__/**,*test-environment.*
+        sonar.coverage.exclusions=**/*.config.js,**/coverage/**,**/integration-tests/**,**/tests/example/**,**/*.test.*,__mocks__/**,*test-environment.*,**/dependency-scan-results/**/*
 
 - script: npm run build:production
   displayName: 'build'


### PR DESCRIPTION
Add dependency check results as an exclusion for sonarqube. This should remove all code smells and bugs from sonarqube.