### PR TITLE
Handle badly formatted cookie value

### DIFF
--- a/src/cookieconsent.js
+++ b/src/cookieconsent.js
@@ -41,20 +41,34 @@ const defaultConsent = {
 /* eslint-enable sort-key */
 
 /**
- * Get the consent cookie and parse it into an object
- */
-function getCookie() {
-  const rawCookie = getRawCookie(COOKIE_NAME);
-  return JSON.parse(rawCookie);
-}
-
-/**
  * Set the consent cookie, turning the value object into a string
  * Creates a new cookie or replaces a cookie if one exists with the same name
  */
 function createCookie(value, days, path, domain, secure) {
   const stringValue = JSON.stringify(value);
   return createRawCookie(COOKIE_NAME, stringValue, days, path, domain, secure);
+}
+
+/**
+ * Get the consent cookie and parse it into an object
+ *
+ * If the cookie cannot be parsed as valid JSON, this function will
+ * reset the cookie to the default settings, and return the new value
+ * of the cookie.
+ */
+function getCookie() {
+  const rawCookie = getRawCookie(COOKIE_NAME);
+  let jsonCookie;
+  try {
+    jsonCookie = JSON.parse(rawCookie);
+  } catch (_err) {
+    jsonCookie = {
+      ...defaultConsent,
+      version: COOKIE_VERSION,
+    };
+    createCookie(jsonCookie, null, '/');
+  }
+  return jsonCookie;
 }
 
 /**

--- a/src/cookieconsent.test.js
+++ b/src/cookieconsent.test.js
@@ -22,12 +22,36 @@ describe('getCookie', () => {
     cookieconsent.__ResetDependency__('getRawCookie');
   });
 
-  test('getCookie throws an error if getRawCookie returns invalid json', () => {
+  test('getCookie returns object of default settings if getRawCookie returns invalid json', () => {
     cookieconsent.__Rewire__('getRawCookie', () => '{abc}');
-    expect(() => {
-      getCookie();
-    }).toThrow(SyntaxError);
+    cookieconsent.__Rewire__('createCookie', () => null);
+    expect(getCookie()).toEqual({
+      consented: false,
+      marketing: false,
+      necessary: true,
+      preferences: false,
+      statistics: false,
+      version: 4,
+    });
     cookieconsent.__ResetDependency__('getRawCookie');
+    cookieconsent.__ResetDependency__('createCookie');
+  });
+
+  test('getCookie resets cookie if getRawCookie returns invalid json', () => {
+    const spy = jest.fn();
+    cookieconsent.__Rewire__('getRawCookie', () => '{abc}');
+    cookieconsent.__Rewire__('createCookie', spy);
+    getCookie();
+    expect(spy).toHaveBeenCalledWith({
+      consented: false,
+      marketing: false,
+      necessary: true,
+      preferences: false,
+      statistics: false,
+      version: 4,
+    }, null, '/');
+    cookieconsent.__ResetDependency__('getRawCookie');
+    cookieconsent.__ResetDependency__('createCookie');
   });
 });
 


### PR DESCRIPTION
If the cookie cannot be parsed as valid JSON, reset the cookie to a sensible default and return this new value. Adds/updates unit tests to reflect this change.
The 'sensible default value' is just `{ ...defaultConsent, version: COOKIE_VERSION` i.e. `{ consented: false, marketing: false, necessary: true, preferences: false, statistics: false, version: 4 }`. This means that the cookie banner will be shown if the cookie is invalid upon page load; I think this makes sense as we don't know if the user has consented or not.
Manually tested in chrome 121 and firefox 122; all unit tests pass.