### PR TITLE
Removing reference to old tools and updating with current tools

### DIFF
--- a/src/banner.html
+++ b/src/banner.html
@@ -1,9 +1,9 @@
-<div id="nhsuk-cookie-banner" data-nosnippet="true">
+<div id="nhsuk-cookie-banner" data-nosnippet>
   <div class="nhsuk-cookie-banner" id="cookiebanner">
     <div class="nhsuk-width-container"> 
         <h2>Cookies on the NHS website</h2> 
         <p>We've put some small files called cookies on your device to make our site work.</p>
-        <p>We'd also like to use analytics cookies. These collect feedback and send information about how our site is used to services called Adobe Analytics, Qualtrics Feedback, Microsoft Clarity and Google Analytics. We use this information to improve our site.</p>
+        <p>We'd also like to use analytics cookies. These collect feedback and send information about how our site is used to services called Adobe Analytics, Adobe Target, Qualtrics Feedback and Google Analytics. We use this information to improve our site.</p>
         <p>Let us know if this is OK. We'll use a cookie to save your choice. You can <a id="nhsuk-cookie-banner__link" href="${require('./settings.js').getPolicyUrl()}">read more about our cookies</a> before you choose.</p>
         <ul> 
             <li><button class='nhsuk-button' id="nhsuk-cookie-banner__link_accept_analytics" href="#">I'm OK with analytics cookies</button></li>


### PR DESCRIPTION
Update the cookie consent to remove the reference to Microsoft Clarity and update it to Adobe target.

I've also removed the `="true"` value on the `data-nosnippet` as it is a boolean attribute any value is ignored – as specified in [the docs](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#data-nosnippet-attr)