### PR TITLE
PROD-1043: add listener for broadcasting shared consent

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -6,5 +6,6 @@ module.exports = {
   launch: {
     // set headless to false if you want to see the tests running locally
     headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cookie-consent",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cookie-consent",
-      "version": "0.5.4",
+      "version": "0.6.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/cli": "^7.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-consent",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "In-house solution for managing cookies on nhs.uk",
   "main": "src/cookieconsent.js",
   "directories": {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,6 +1,7 @@
 // N.B document.currentScript needs to be executed outside of any callbacks
 // https://developer.mozilla.org/en-US/docs/Web/API/Document/currentScript#Notes
 const scriptTag = document.currentScript;
+const PUBLIC_NHS_SUFFIX = 'nhs.uk';
 
 // get properties from the scriptTag for the policy URL
 export function getPolicyUrl() {
@@ -46,4 +47,29 @@ export function getNoBanner() {
   }
 
   return defaults;
+}
+
+/**
+ * Determines if a link should be skipped from further processing
+ * @param {HTMLAnchorElement} link - The anchor element to check
+ * @returns {boolean} - Whether the link should be skipped
+ */
+export function shouldSkipLinkProcessing(link) {
+  if (!link) {
+    return true;
+  }
+
+  try {
+    const linkUrl = new URL(link.href);
+
+    // Check if the link is to an external hostname
+    const isExternalLink = linkUrl.hostname.endsWith(PUBLIC_NHS_SUFFIX) == false;
+    // Check if the link is to the policy page
+    const isPolicyPage = linkUrl.href.endsWith(getPolicyUrl());
+
+    return isExternalLink || isPolicyPage;
+  } catch (error) {
+    // not a valid URL, so we can't process it
+    return true;
+  }
 }

--- a/src/settings.test.js
+++ b/src/settings.test.js
@@ -1,6 +1,6 @@
 /* global expect, jest, afterEach */
 
-import settings, { getNoBanner, getPolicyUrl, makeUrlAbsolute } from './settings';
+import settings, { getNoBanner, getPolicyUrl, makeUrlAbsolute, shouldSkipLinkProcessing } from './settings';
 
 describe('get script settings for no banner', () => {
   afterEach(() => {
@@ -106,3 +106,26 @@ describe('get an absolute URL', () => {
   });
 });
 
+describe("shouldSkipLinkProcessing", () => {
+  it.each`
+    description                   | href                                                  | expected
+    ${"null link"}                | ${null}                                               | ${true}
+    ${"undefined link"}           | ${undefined}                                          | ${true}
+    ${"external link"}            | ${"https://external.com/page"}                        | ${true}
+    ${"internal non-policy link"} | ${"https://mock.nhs.uk/home"}                         | ${false}
+    ${"internal non-policy link"} | ${"https://nhs.uk"}                                   | ${false}
+    ${"internal non-policy link"} | ${"https://www.nhs.uk"}                               | ${false}
+    ${"internal non-policy link"} | ${"https://assets.nhs.uk"}                            | ${false}
+    ${"internal policy link"}     | ${"https://mock.nhs.uk/our-policies/cookies-policy/"} | ${true}
+
+  `("$description", ({ href, expected }) => {
+    let link = null;
+    if (href !== null && href !== undefined) {
+      link = document.createElement("a");
+      link.href = href;
+    }
+
+    const result = shouldSkipLinkProcessing(link);
+    expect(result).toBe(expected);
+  });
+});

--- a/tests/example/css/style.css
+++ b/tests/example/css/style.css
@@ -5,3 +5,8 @@ body {
 main {
   margin: 1em;
 }
+
+button, a {
+  display: block;
+  margin-bottom: 10px;
+}

--- a/tests/example/custom-link.html
+++ b/tests/example/custom-link.html
@@ -28,7 +28,12 @@
   <body>
     <main class="main">
       <h1>Cookies:</h1>
-      <button id="cookie-list-refresh">Refresh</button>
+      <div>
+        <button id="cookie-list-refresh">Refresh</button>
+         <!-- Link for broadcasting shared consent query string parameter when cookie is consented -->
+        <a id="internal-link" href="https://www.nhs.uk/">Internal Link</a>
+        <a id="external-link" href="https://www.google.com/">Externall Link</a>
+      </div>
       <div id="cookie-list"></div>
 
       <iframe data-src="https://example.com" data-cookieconsent="statistics" title="Example Content"></iframe>

--- a/tests/example/index.html
+++ b/tests/example/index.html
@@ -30,7 +30,6 @@
       <h1>Cookies:</h1>
       <button id="cookie-list-refresh">Refresh</button>
       <div id="cookie-list"></div>
-
       <iframe data-src="https://example.com" data-cookieconsent="statistics" title="Example Content"></iframe>
 
       <script src="./js/show-cookie-data.js"></script>

--- a/tests/example/js/show-cookie-data.js
+++ b/tests/example/js/show-cookie-data.js
@@ -25,7 +25,6 @@
       container.innerHTML = '<p>No cookies to show</p>';
     }
   }
-
   refreshButton.addEventListener('click', listCookies);
   listCookies();
 }());

--- a/tests/integration-tests/banner.test.js
+++ b/tests/integration-tests/banner.test.js
@@ -132,3 +132,53 @@ describe('custom banner url link', () => {
     expect(banner).not.toBe(null);
   });
 });
+
+describe('broadcast share consent', () => {
+  beforeEach(async () => {
+    await clearAllCookies();
+    await page.goto('http://localhost:8080/tests/example/custom-link.html');
+    await waitForVisibleBanner();
+  });
+
+  it('internal link click without consent does not append tracking parameter', async () => {
+    await page.click('#internal-link');
+    expect(page.url()).toEqual('https://www.nhs.uk/');
+  });
+
+  it('internal link click when analytics consent is given appends tracking parameter', async () => {
+    await page.click('#nhsuk-cookie-banner__link_accept_analytics');
+    await waitForHiddenBanner()
+    
+    await page.click('#internal-link');
+    expect(page.url()).toEqual('https://www.nhs.uk/?nhsa.sc=1');
+  });
+
+  it('internal link click when consent is given appends tracking parameter', async () => {
+    await page.click('#nhsuk-cookie-banner__link_accept');
+    await waitForHiddenBanner()
+    
+    await page.click('#internal-link');
+    expect(page.url()).toEqual('https://www.nhs.uk/?nhsa.sc=0');
+  });
+
+  it('external link without consent does not append tracking parameter', async () => {
+    await page.click('#external-link');
+    expect(page.url()).toEqual('https://www.google.com/');
+  });
+
+    it('external link when analytics consent is given does not append tracking parameter', async () => {
+    await page.click('#nhsuk-cookie-banner__link_accept_analytics');
+    await waitForHiddenBanner()
+    
+    await page.click('#external-link');
+    expect(page.url()).toEqual('https://www.google.com/');
+  });
+
+   it('external link when consent is given does not append tracking parameter', async () => {
+    await page.click('#nhsuk-cookie-banner__link_accept');
+    await waitForHiddenBanner()
+    
+    await page.click('#external-link');
+    expect(page.url()).toEqual('https://www.google.com/');
+  });
+})


### PR DESCRIPTION
Add click listener for broadcasting of shared consent query string parameter.

- When cookie-consent cookie is not present, do not attach anything onto the request URL
- When cookie-consent cookie is present, but consent option is false, do not attach anything onto the request URL
- When cookie-consent cookie is present, and cookie-consent 'analytic' (statistics) option is true and cookie-consent 'consent' option is true, attach nhsa.sc=1 onto the request URL as a querystring
- When cookie-consent cookie is present, and cookie-consent 'analytic' (statistics) option is false and cookie-consent 'consent' option is true, attach nhsa.sc=0 onto the request URL as a querystring.

Disabling Puppeteer in sandbox as its not available in latest linux version environment where the pipeline is running.

- As in CI environment is not guaranteed to be available and also we are not running  arbitrary untrusted code or browsing 